### PR TITLE
minified version of FATFS

### DIFF
--- a/CFW_loader/source/fatfs/ffconf.h
+++ b/CFW_loader/source/fatfs/ffconf.h
@@ -23,7 +23,7 @@
 /  f_rename(), f_truncate() and useless f_getfree(). */
 
 
-#define _FS_MINIMIZE    0   /* 0 to 3 */
+#define _FS_MINIMIZE    2   /* 0 to 3 */
 /* The _FS_MINIMIZE option defines minimization level to remove API functions.
 /
 /   0: All basic functions are enabled.


### PR DESCRIPTION
``` C
#define _FS_MINIMIZE    0   /* 0 to 3 */
/* The _FS_MINIMIZE option defines minimization level to remove API functions.
/
/   0: All basic functions are enabled.
/   1: f_stat(), f_getfree(), f_unlink(), f_mkdir(), f_chmod(), f_utime(),
/      f_truncate() and f_rename() function are removed.
/   2: f_opendir(), f_readdir() and f_closedir() are removed in addition to 1.
/   3: f_lseek() function is removed in addition to 2. */
```

As mentioned above in FATFS `ffconf.h`, this could remove several functions.
I've checked and find no usage of those except `f_lseek`, from compiled binary.
This would decrease the binary size by almost 2KB.
**But be aware: please reject this if planned to use those functions later.**
