### PR TITLE
Simple tweaks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+.DS_Store
+
 # Compiled Object files
 *.o
+*.d
+*.bin
+*.elf
+*.smdh
+*.3dsx
 
 # Visual Studio
 *.opensdf
@@ -25,6 +32,6 @@
 # Copyrighted files
 
 # Objects
-/PastaCFW Configurator/PastaCFW Configurator/obj
-
-.DS_Store
+*/obj
+*/build
+*/builds

--- a/CFW_loader/include/platform.h
+++ b/CFW_loader/include/platform.h
@@ -8,6 +8,9 @@ typedef enum {
 #define SYSTEM_VERSION(major, minor, revision) \
 	(((major)<<24)|((minor)<<16)|((revision)<<8))
 
-Platform GetUnitPlatform();
-u32 osGetFirmVersion();
-u32 osGetKernelVersion();
+extern char *platform_FWStrings[];
+
+Platform Platform_CheckUnit();
+//Un-implemented
+//u32 osGetFirmVersion();
+//u32 osGetKernelVersion();

--- a/CFW_loader/source/draw.c
+++ b/CFW_loader/source/draw.c
@@ -24,7 +24,7 @@ void DrawCharacter(unsigned char *screen, int character, int x, int y, int color
 {
     int yy, xx;
     u8 foreColorR = color & 0xFF, foreColorG = color >> 8, foreColorB = color >> 16;
-    u8 backColorR = bgcolor & 0xFF, backColorG = bgcolor >> 8, backColorB = color >> 16;
+    u8 backColorR = bgcolor & 0xFF, backColorG = bgcolor >> 8, backColorB = bgcolor >> 16;
     for (yy = 0; yy < 8; yy++) {
         int xDisplacement = (x * BYTES_PER_PIXEL * SCREEN_WIDTH);
         int yDisplacement = ((SCREEN_WIDTH - (y + yy) - 1) * BYTES_PER_PIXEL);

--- a/CFW_loader/source/draw.c
+++ b/CFW_loader/source/draw.c
@@ -11,11 +11,12 @@ int current_y = 0;
 void ClearScreen(unsigned char *screen, int color)
 {
     int i;
+    u8 colorR = color & 0xFF, colorG = color >> 8, colorB = color >> 16;
     unsigned char *screenPos = screen;
     for (i = 0; i < (SCREEN_HEIGHT * SCREEN_WIDTH); i++) {
-        *(screenPos++) = color >> 16;  // B
-        *(screenPos++) = color >> 8;   // G
-        *(screenPos++) = color & 0xFF; // R
+        *(screenPos++) = colorB;  // B
+        *(screenPos++) = colorG;   // G
+        *(screenPos++) = colorR; // R
     }
 }
 

--- a/CFW_loader/source/draw.c
+++ b/CFW_loader/source/draw.c
@@ -48,8 +48,8 @@ void DrawCharacter(unsigned char *screen, int character, int x, int y, int color
 
 void DrawString(unsigned char *screen, const char *str, int x, int y, int color, int bgcolor)
 {
-    int i;
-    for (i = 0; i < strlen(str); i++)
+    u32 i = 0, len = strlen(str);
+    for (i = 0; i < len; i++)
         DrawCharacter(screen, str[i], x + i * 8, y, color, bgcolor);
 }
 

--- a/CFW_loader/source/draw.c
+++ b/CFW_loader/source/draw.c
@@ -22,6 +22,8 @@ void ClearScreen(unsigned char *screen, int color)
 void DrawCharacter(unsigned char *screen, int character, int x, int y, int color, int bgcolor)
 {
     int yy, xx;
+    u8 foreColorR = color & 0xFF, foreColorG = color >> 8, foreColorB = color >> 16;
+    u8 backColorR = bgcolor & 0xFF, backColorG = bgcolor >> 8, backColorB = color >> 16;
     for (yy = 0; yy < 8; yy++) {
         int xDisplacement = (x * BYTES_PER_PIXEL * SCREEN_WIDTH);
         int yDisplacement = ((SCREEN_WIDTH - (y + yy) - 1) * BYTES_PER_PIXEL);
@@ -30,13 +32,13 @@ void DrawCharacter(unsigned char *screen, int character, int x, int y, int color
         unsigned char charPos = font[character * 8 + yy];
         for (xx = 7; xx >= 0; xx--) {
             if ((charPos >> xx) & 1) {
-                *(screenPos + 0) = color >> 16;  // B
-                *(screenPos + 1) = color >> 8;   // G
-                *(screenPos + 2) = color & 0xFF; // R
+                *(screenPos + 0) = foreColorB;  // B
+                *(screenPos + 1) = foreColorG;   // G
+                *(screenPos + 2) = foreColorR; // R
             } else {
-                *(screenPos + 0) = bgcolor >> 16;  // B
-                *(screenPos + 1) = bgcolor >> 8;   // G
-                *(screenPos + 2) = bgcolor & 0xFF; // R
+                *(screenPos + 0) = backColorB;  // B
+                *(screenPos + 1) = backColorG;   // G
+                *(screenPos + 2) = backColorR; // R
             }
             screenPos += BYTES_PER_PIXEL * SCREEN_WIDTH;
         }

--- a/CFW_loader/source/fatfs/sdmmc.h
+++ b/CFW_loader/source/fatfs/sdmmc.h
@@ -45,7 +45,7 @@ void sdmmc_sdcard_init();
 int sdmmc_sdcard_readsector(uint32_t sector_no, uint8_t *out);
 int sdmmc_sdcard_readsectors(uint32_t sector_no, uint32_t numsectors, uint8_t *out);
 int sdmmc_sdcard_writesector(uint32_t sector_no, uint8_t *in);
-int sdmmc_sdcard_writesectors(uint32_t sector_no, uint32_t numsectors, uint8_t *in);
+int sdmmc_sdcard_writesectors(uint32_t sector_no, uint32_t numsectors, const uint8_t *in);
 
 int sdmmc_nand_readsectors(uint32_t sector_no, uint32_t numsectors, uint8_t *out);
 int sdmmc_nand_writesectors(uint32_t sector_no, uint32_t numsectors, uint8_t *in);

--- a/CFW_loader/source/fs.c
+++ b/CFW_loader/source/fs.c
@@ -21,7 +21,7 @@ bool FileOpen(const char* path)
 {
 	unsigned flags = FA_READ | FA_WRITE | FA_OPEN_EXISTING;
 	bool ret = (f_open(&file, path, flags) == FR_OK);
-	f_lseek(&file, 0);
+	//f_lseek(&file, 0);
 	f_sync(&file);
 	return ret;
 }
@@ -31,7 +31,7 @@ bool FileCreate(const char* path, bool truncate)
 	unsigned flags = FA_READ | FA_WRITE;
 	flags |= truncate ? FA_CREATE_ALWAYS : FA_OPEN_ALWAYS;
 	bool ret = (f_open(&file, path, flags) == FR_OK);
-	f_lseek(&file, 0);
+	//f_lseek(&file, 0);
 	f_sync(&file);
 	return ret;
 }

--- a/CFW_loader/source/main.c
+++ b/CFW_loader/source/main.c
@@ -98,70 +98,48 @@ void bootCFW_SecondStage()
 	//Apply patches
 	DebugNoNewLine("Apply patch for type %c...", type);
 	if (type == '1'){ // 4.x
-		u32 *dest = 0x080549C4;
-		u32 *dest1 = 0x0804239C;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x080549C4, patch, 4);
+		memcpy((u32*)0x0804239C, patch1, 4);
 	}
 	else if (type == '2'){ // 5.0
-		u32 *dest = 0x08051650;
-		u32 *dest1 = 0x0803C838;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x08051650, patch, 4);
+		memcpy((u32*)0x0803C838, patch1, 4);
 	}
 	else if (type == '3'){ // 5.1
-		u32 *dest = 0x0805164C;
-		u32 *dest1 = 0x0803C838;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x0805164C, patch, 4);
+		memcpy((u32*)0x0803C838, patch1, 4);
 	}
 	else if (type == '4'){ // 6.0
-		u32 *dest = 0x0805235C;
-		u32 *dest1 = 0x08057FE4;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x0805235C, patch, 4);
+		memcpy((u32*)0x08057FE4, patch1, 4);
 	}
 	else if (type == '5'){ // 6.1 - 6.3
-		u32 *dest = 0x08051B5C;
-		u32 *dest1 = 0x08057FE4;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x08051B5C, patch, 4);
+		memcpy((u32*)0x08057FE4, patch1, 4);
 	}
 	else if (type == '6'){ // 7.0-7.1
-		u32 *dest = 0x080521C4;
-		u32 *dest1 = 0x08057E98;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x080521C4, patch, 4);
+		memcpy((u32*)0x08057E98, patch1, 4);
 	}
 	else if (type == '7'){ // 7.2
-		u32 *dest = 0x080521C8;
-		u32 *dest1 = 0x08057E9C;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x080521C8, patch, 4);
+		memcpy((u32*)0x08057E9C, patch1, 4);
 	}
 	else if (type == '8'){ // 8.x
-		u32 *dest = 0x080523C4;
-		u32 *dest1 = 0x08058098;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x080523C4, patch, 4);
+		memcpy((u32*)0x08058098, patch1, 4);
 	}
 	else if (type == '9'){ // 9.x
-		u32 *dest = 0x0805235C;
-		u32 *dest1 = 0x08058100;
-		memcpy(dest, patch, 4);
-		memcpy(dest1, patch1, 4);
+		memcpy((u32*)0x0805235C, patch, 4);
+		memcpy((u32*)0x08058100, patch1, 4);
 	}
 	else if (type == 'a'){ // 8.x
-		u32 *dest = 0x08053114;
-		u32 *dest1 = 0x080587E0;
-		memcpy(dest, patch2, 4);
-		memcpy(dest1, patch3, 4);
+		memcpy((u32*)0x08053114, patch2, 4);
+		memcpy((u32*)0x080587E0, patch3, 4);
 	}
 	else if (type == 'b'){ // 9.x
-		u32 *dest = 0x08052FD8;
-		u32 *dest1 = 0x08058804;
-		memcpy(dest, patch4, 4);
-		memcpy(dest1, patch5, 4);
+		memcpy((u32*)0x08052FD8, patch4, 4);
+		memcpy((u32*)0x08058804, patch5, 4);
 	}
 	Debug("Apply patch for type %c...                  Done!", type);
 }
@@ -185,7 +163,7 @@ void arm9dumper()
 		u32 total = 0;
 		u32 result = 0;
 		u32 num = 0;
-		void *addr = 0x08000000;
+		void *addr = (void*)0x08000000;
 		u32 size = 0x00100000;
 		const u32 sz_chunk = 0x10000;
 

--- a/CFW_loader/source/main.c
+++ b/CFW_loader/source/main.c
@@ -39,47 +39,47 @@ void getSystemVersion()
 	{
 	case '1': // 4.x
 		type = '1';
-		systemVersion = "Old 3DS V. 4.1 - 4.5";
+		systemVersion = platform_FWStrings[0];
 		break;
 	case '2': // 5.0
 		type = '2';
-		systemVersion = "Old 3DS V. 5.0";
+		systemVersion = platform_FWStrings[1];
 		break;
 	case '3': // 5.1
 		type = '3';
-		systemVersion = "Old 3DS V. 5.1";
+		systemVersion = platform_FWStrings[2];
 		break;
 	case '4': // 6.0
 		type = '4';
-		systemVersion = "Old 3DS V. 6.0";
+		systemVersion = platform_FWStrings[3];
 		break;
 	case '5': // 6.1 - 6.3
 		type = '5';
-		systemVersion = "Old 3DS V. 6.1 - 6.3";
+		systemVersion = platform_FWStrings[4];
 		break;
 	case '6': // 7.0-7.1
 		type = '6';
-		systemVersion = "Old 3DS V. 7.0 - 7.1";
+		systemVersion = platform_FWStrings[5];
 		break;
 	case '7': // 7.2
 		type = '7';
-		systemVersion = "Old 3DS V. 7.2";
+		systemVersion = platform_FWStrings[6];
 		break;
 	case '8': // 8.x
 		type = '8';
-		systemVersion = "Old 3DS V. 8.0 - 8.1";
+		systemVersion = platform_FWStrings[7];
 		break;
 	case '9': // 9.x
 		type = '9';
-		systemVersion = "Old 3DS V. 9.0 - 9.2";
+		systemVersion = platform_FWStrings[8];
 		break;
 	case 'a': // 8.x
 		type = 'a';
-		systemVersion = "New 3DS V. 8.1";
+		systemVersion = platform_FWStrings[9];
 		break;
 	case 'b': // 9.x
 		type = 'b';
-		systemVersion = "New 3DS V. 9.0 - 9.2";
+		systemVersion = platform_FWStrings[10];
 		break;
 	}
 

--- a/CFW_loader/source/platform.c
+++ b/CFW_loader/source/platform.c
@@ -3,6 +3,21 @@
 
 #define CONFIG_PLATFORM_REG ((volatile u32*)0x10140FFC)
 
+// Strings of All supported firmware versions, currently.
+char *platform_FWStrings[] = {
+    "Old 3DS V. 4.1 - 4.5",
+    "Old 3DS V. 5.0",
+    "Old 3DS V. 5.1",
+    "Old 3DS V. 6.0",
+    "Old 3DS V. 6.1 - 6.3",
+    "Old 3DS V. 7.0 - 7.1",
+    "Old 3DS V. 7.2",
+    "Old 3DS V. 8.0 - 8.1",
+    "Old 3DS V. 9.0 - 9.2",
+    "New 3DS V. 8.1",
+    "New 3DS V. 9.0 - 9.2"
+};
+
 Platform GetUnitPlatform()
 {
     switch (*CONFIG_PLATFORM_REG) {


### PR DESCRIPTION
The commits including these changes:
- **TWEAK** Cache the R,G,B for `DrawCharacter` and `ClearScreen`. Cache length for `DrawString`.
- **SPACE** Use `platform_FWStrings` to store all those version we support, maybe used in other functions. Not much difference from the original.
- **SPACE** Cast address to pointers explicitly to pass some warnings.
- **TWEAK** Removed two f_lseek calls. The File R/W use absolute offset and it is called there.
- **SPACE** Pass the warning related to `diskio.c` with just a `const` modifier.

I would remake some commits to periodly rename/comment the `CFW_loader` code days later.
