### PR TITLE
Port and update gfx and release scripts

### DIFF
--- a/CFW_loader/gfx/makepng-all.bat
+++ b/CFW_loader/gfx/makepng-all.bat
@@ -1,0 +1,22 @@
+@echo off
+for /r %%i in (menu?.bin) do (
+call :conv %%i 320
+)
+for /r %%i in (nand*.bin) do (
+call :conv %%i 320
+)
+for /r %%i in (arm*.bin) do (
+call :conv %%i 320
+)
+
+call :conv options.bin 320
+
+for /r %%i in (*TOP.bin) do (
+call :conv %%i 400
+)
+GOTO:EOF
+
+:conv
+del UI\%~n1.png command > nul 2>&1
+convert -size 240x%2 -depth 8 bgr:%1 -size %2x240 -rotate 270 %~n1.png
+GOTO:EOF

--- a/CFW_loader/gfx/makepng-all.sh
+++ b/CFW_loader/gfx/makepng-all.sh
@@ -5,5 +5,5 @@ done
 
 for f in *TOP.bin
 do
-convert -size 240x400 -depth 8 bgr\:$f -size 400x240 -rotate 270 ${f%.*}.png
+	convert -size 240x400 -depth 8 bgr\:$f -size 400x240 -rotate 270 ${f%.*}.png
 done

--- a/CFW_loader/gfx/makeprev.bat
+++ b/CFW_loader/gfx/makeprev.bat
@@ -1,7 +1,10 @@
 @echo off
 
+set delay=%1
+if "%delay%" == "" set delay=100
+
 if not exist template.png (
-	bitsadmin /transfer "3DS-Template" http://www.nintendo.com/images/page/3ds/what-is-3ds/hero-new-3ds.png %cd%\template.png
+	bitsadmin /transfer "3DS-Template" /download /priority high http://www.nintendo.com/images/page/3ds/what-is-3ds/hero-new-3ds.png %cd%\template.png
 )
 
 mkdir Preview\Images\AIO Preview\Images\Menu Preview\Images\NAND-dump Preview\Images\ARM9-dump Preview\Animations\AIO Preview\Animations\Menu Preview\Animations\NAND-dump Preview\Animations\ARM9-dump
@@ -38,14 +41,14 @@ if exist creditsTOP.png (
 )
 
 convert Preview\menu0.png Preview\menu6.png Preview\nand0.png +append Preview\menuprev-aio.png
-convert -delay 100 -loop 0 menu0.png menu1.png menu2.png menu3.png menu4.png menu5.png menu6.png Preview\menuprev-1.gif
-convert -delay 100 -loop 0 Preview\menu0.png Preview\menu1.png Preview\menu2.png Preview\menu3.png Preview\menu4.png Preview\menu5.png Preview\menu6.png Preview\menuprev-2.gif
-convert -delay 100 -loop 0 nand0.png nand1.png nand2OK.png nand2E.png Preview\nand-0.gif
-convert -delay 100 -loop 0 Preview\nand0.png Preview\nand1.png Preview\nand2OK.png Preview\nand2E.png Preview\nand-1.gif
-convert -delay 100 -loop 0 arm90.png arm91.png arm92OK.png arm92E.png Preview\arm9-0.gif
-convert -delay 100 -loop 0 Preview\arm90.png Preview\arm91.png Preview\arm92OK.png Preview\arm92E.png Preview\arm9-1.gif
-convert -delay 100 -loop 0 menu0.png menu1.png menu2.png menu3.png menu4.png menu5.png menu6.png options.png nand0.png nand1.png nand2OK.png nand2E.png arm90.png arm91.png arm92OK.png arm92E.png Preview\menuprev-aio-0.gif
-convert -delay 100 -loop 0 Preview\menu0.png Preview\menu1.png Preview\menu2.png Preview\menu3.png Preview\menu4.png Preview\menu5.png Preview\menu6.png Preview\options.png Preview\nand0.png Preview\nand1.png Preview\nand2OK.png Preview\nand2E.png Preview\arm90.png Preview\arm91.png Preview\arm92OK.png Preview\arm92E.png Preview\menuprev-aio-1.gif
+convert -delay %delay% -loop 0 menu0.png menu1.png menu2.png menu3.png menu4.png menu5.png menu6.png Preview\menuprev-1.gif
+convert -delay %delay% -loop 0 Preview\menu0.png Preview\menu1.png Preview\menu2.png Preview\menu3.png Preview\menu4.png Preview\menu5.png Preview\menu6.png Preview\menuprev-2.gif
+convert -delay %delay% -loop 0 nand0.png nand1.png nand2OK.png nand2E.png Preview\nand-0.gif
+convert -delay %delay% -loop 0 Preview\nand0.png Preview\nand1.png Preview\nand2OK.png Preview\nand2E.png Preview\nand-1.gif
+convert -delay %delay% -loop 0 arm90.png arm91.png arm92OK.png arm92E.png Preview\arm9-0.gif
+convert -delay %delay% -loop 0 Preview\arm90.png Preview\arm91.png Preview\arm92OK.png Preview\arm92E.png Preview\arm9-1.gif
+convert -delay %delay% -loop 0 menu0.png menu1.png menu2.png menu3.png menu4.png menu5.png menu6.png options.png nand0.png nand1.png nand2OK.png nand2E.png arm90.png arm91.png arm92OK.png arm92E.png Preview\menuprev-aio-0.gif
+convert -delay %delay% -loop 0 Preview\menu0.png Preview\menu1.png Preview\menu2.png Preview\menu3.png Preview\menu4.png Preview\menu5.png Preview\menu6.png Preview\options.png Preview\nand0.png Preview\nand1.png Preview\nand2OK.png Preview\nand2E.png Preview\arm90.png Preview\arm91.png Preview\arm92OK.png Preview\arm92E.png Preview\menuprev-aio-1.gif
 
 cd Preview
 

--- a/CFW_loader/gfx/makeprev.sh
+++ b/CFW_loader/gfx/makeprev.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+if [ $# -eq 0 ]; then
+	delay="100"
+else
+	delay=$1
+fi
+
 if [ ! -f template.png ]; then
 	curl -O "http://www.nintendo.com/images/page/3ds/what-is-3ds/hero-new-3ds.png"
 	mv hero-new-3ds.png template.png
@@ -51,14 +57,14 @@ else
 fi
 
 convert Preview/menu0.png Preview/menu6.png Preview/nand0.png +append Preview/menuprev-aio.png
-convert -delay 100 -loop 0 menu?.png Preview/menuprev-1.gif
-convert -delay 100 -loop 0 Preview/menu?.png Preview/menuprev-2.gif
-convert -delay 100 -loop 0 nand?.png nand2OK.png nand2E.png Preview/nand-0.gif
-convert -delay 100 -loop 0 Preview/nand?.png Preview/nand2OK.png Preview/nand2E.png Preview/nand-1.gif
-convert -delay 100 -loop 0 arm9?.png arm92OK.png arm92E.png Preview/arm9-0.gif
-convert -delay 100 -loop 0 Preview/arm9?.png Preview/arm92OK.png Preview/arm92E.png Preview/arm9-1.gif
-convert -delay 100 -loop 0 menu?.png options.png nand?.png nand2OK.png nand2E.png arm9?.png arm92OK.png arm92E.png Preview/menuprev-aio-0.gif
-convert -delay 100 -loop 0 Preview/menu?.png Preview/options.png Preview/nand?.png Preview/nand2OK.png Preview/nand2E.png Preview/arm9?.png Preview/arm92OK.png Preview/arm92E.png Preview/menuprev-aio-1.gif
+convert -delay $delay -loop 0 menu?.png Preview/menuprev-1.gif
+convert -delay $delay -loop 0 Preview/menu?.png Preview/menuprev-2.gif
+convert -delay $delay -loop 0 nand?.png nand2OK.png nand2E.png Preview/nand-0.gif
+convert -delay $delay -loop 0 Preview/nand?.png Preview/nand2OK.png Preview/nand2E.png Preview/nand-1.gif
+convert -delay $delay -loop 0 arm9?.png arm92OK.png arm92E.png Preview/arm9-0.gif
+convert -delay $delay -loop 0 Preview/arm9?.png Preview/arm92OK.png Preview/arm92E.png Preview/arm9-1.gif
+convert -delay $delay -loop 0 menu?.png options.png nand?.png nand2OK.png nand2E.png arm9?.png arm92OK.png arm92E.png Preview/menuprev-aio-0.gif
+convert -delay $delay -loop 0 Preview/menu?.png Preview/options.png Preview/nand?.png Preview/nand2OK.png Preview/nand2E.png Preview/arm9?.png Preview/arm92OK.png Preview/arm92E.png Preview/menuprev-aio-1.gif
 
 cd Preview
 

--- a/release.bat
+++ b/release.bat
@@ -6,8 +6,8 @@ echo .
 echo IMPORTANT: The executable bit of pastaConfig and sh scripts cannot be set in Windows. Please use the sh script if possible.
 
 cd Brahma_Fork
-::make clean
-::make
+make clean
+make
 if not exist PastaCFW.smdh (
 	cd..
 	echo "ERROR: Cannot find PastaCFW.smdh."
@@ -20,8 +20,8 @@ if not exist PastaCFW.3dsx (
 )
 
 cd ..\CFW_loader
-::make clean
-::make
+make clean
+make
 if not exist loader.bin (
 	echo "ERROR: Cannot find loader.bin."
 	GOTO:EOF

--- a/release.bat
+++ b/release.bat
@@ -3,7 +3,7 @@
 echo NOTE: You need to build the companion apps before using this script.
 echo The folder Pasta-Release will be erased, and PastaCFW.zip too.
 echo .
-echo IMPORTANT: The executable bit of pastaConfig cannot be set in Windows. Please use the sh script if possible.
+echo IMPORTANT: The executable bit of pastaConfig and sh scripts cannot be set in Windows. Please use the sh script if possible.
 
 cd Brahma_Fork
 ::make clean

--- a/release.bat
+++ b/release.bat
@@ -1,0 +1,68 @@
+@echo off
+
+echo NOTE: You need to build the companion apps before using this script.
+echo The folder Pasta-Release will be erased, and PastaCFW.zip too.
+echo .
+echo IMPORTANT: The executable bit of pastaConfig cannot be set in Windows. Please use the sh script if possible.
+
+cd Brahma_Fork
+::make clean
+::make
+if not exist PastaCFW.smdh (
+	cd..
+	echo "ERROR: Cannot find PastaCFW.smdh."
+	GOTO:EOF
+)
+if not exist PastaCFW.3dsx (
+	cd..
+	echo "ERROR: Cannot find PastaCFW.3dsx."
+	GOTO:EOF
+)
+
+cd ..\CFW_loader
+::make clean
+::make
+if not exist loader.bin (
+	echo "ERROR: Cannot find loader.bin."
+	GOTO:EOF
+)
+
+cd ..
+rd /S /Q Pasta-Release
+mkdir Pasta-Release\3ds\PastaCFW\UI\0
+copy Brahma_Fork\PastaCFW.smdh Pasta-Release\3ds\PastaCFW\
+copy Brahma_Fork\PastaCFW.3dsx Pasta-Release\3ds\PastaCFW\
+copy CFW_loader\loader.bin Pasta-Release\3ds\PastaCFW\
+copy CFW_loader\gfx\*.* Pasta-Release\3ds\PastaCFW\UI\0\
+cd Pasta-Release\3ds\PastaCFW\UI\0\ 
+
+for /r %%i in (*.png) do (
+echo Preparing %%~ni
+del %%~pi\%%~ni.bin command > nul 2>&1
+del %%~pi\%%~ni.bgr command > nul 2>&1
+convert -rotate 90 %%i %%~ni.bgr
+rename %%~ni.bgr %%~ni.bin
+)
+
+cd ..\..\..\..\..\
+del Pasta-Release\3ds\PastaCFW\UI\0\*.png
+copy "Companion_App\Mac-Linux\pastaConfig\builds\GNU-Linux 32 bit\pastaConfig" Pasta-Release\pastaConfig-32bit
+copy "Companion_App\Mac-Linux\pastaConfig\builds\GNU-Linux 64 bit\pastaConfig" Pasta-Release\pastaConfig-64bit
+copy "Companion_App\Windows\PastaCFW Configurator\PastaCFW Configurator\bin\Debug\PastaCFW Configurator.exe" Pasta-Release\
+del PastaCFW.zip
+if exist "%programfiles%\7-Zip\7z.exe" (
+	echo Using 7-Zip.
+	cd Pasta-Release
+	"%programfiles%\7-Zip\7z.exe" -mx10 a "..\PastaCFW.zip" "*"
+	cd ..
+	rd /S /Q Pasta-Release
+) else if exist "%programfiles%\WinRAR\WinRAR.exe" (
+		echo Using WinRAR.
+		cd Pasta-Release
+		"%programfiles%\WinRAR\WinRAR.exe" a -afzip -r -m5 "..\PastaCFW.zip" "*"
+		cd ..
+		rd /S /Q Pasta-Release
+	) else (
+		echo WARNING: 7-Zip or WinRAR not found in "%programfiles%". Skipping zip packaging.
+	)
+)

--- a/release.sh
+++ b/release.sh
@@ -27,6 +27,7 @@ cp CFW_loader/gfx/*.* Pasta-Release/3ds/PastaCFW/UI/0/
 rm Pasta-Release/3ds/PastaCFW/UI/0/*.png
 cp Companion_App/Mac-Linux/pastaConfig/builds/GNU-Linux\ 32\ bit/pastaConfig Pasta-Release/pastaConfig-32bit
 cp Companion_App/Mac-Linux/pastaConfig/builds/GNU-Linux\ 64\ bit/pastaConfig Pasta-Release/pastaConfig-64bit
+chmod +x Pasta-Release/pastaConfig-32bit Pasta-Release/pastaConfig-64bit
 cp Companion_App/Windows/PastaCFW\ Configurator/PastaCFW\ Configurator/bin/Debug/PastaCFW\ Configurator.exe Pasta-Release/
 rm PastaCFW.zip
 (cd Pasta-Release && zip -r -9 ../PastaCFW.zip .)

--- a/release.sh
+++ b/release.sh
@@ -27,7 +27,7 @@ cp CFW_loader/gfx/*.* Pasta-Release/3ds/PastaCFW/UI/0/
 rm Pasta-Release/3ds/PastaCFW/UI/0/*.png
 cp Companion_App/Mac-Linux/pastaConfig/builds/GNU-Linux\ 32\ bit/pastaConfig Pasta-Release/pastaConfig-32bit
 cp Companion_App/Mac-Linux/pastaConfig/builds/GNU-Linux\ 64\ bit/pastaConfig Pasta-Release/pastaConfig-64bit
-chmod +x Pasta-Release/pastaConfig-32bit Pasta-Release/pastaConfig-64bit
+chmod +x Pasta-Release/pastaConfig-32bit Pasta-Release/pastaConfig-64bit Pasta-Release/3ds/PastaCFW/UI/0/*.sh
 cp Companion_App/Windows/PastaCFW\ Configurator/PastaCFW\ Configurator/bin/Debug/PastaCFW\ Configurator.exe Pasta-Release/
 rm PastaCFW.zip
 (cd Pasta-Release && zip -r -9 ../PastaCFW.zip .)


### PR DESCRIPTION
Summary of Changes:
- ported all shell scripts to Windows (release.bat requires devkitPro/ARM, ImageMagick and optionally 7-Zip or WinRAR)
- added chmod +x for pastaConfig and shell scripts in release.sh (impossible in Windows, maybe)
- added an argument to makeprev to specify the delay between frames of the generated gif files
- added high priority to the download of the template in makeprev.bat, should speed up the download of the template a bit
